### PR TITLE
feat: per-LDAP-federation Multifactor API credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/
 target/
+.m2/
 pom.xml.tag
 pom.xml.releaseBackup
 pom.xml.versionsBackup

--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ $ cp <keycloack dir>/target/keycloak-multifactor-spi-jar-with-dependencies.jar <
 4. In KeyCloak "Authentication" -> "Flow" select "Copy of browser" and click "Add step" to "Copy of browser forms" and select `Multifactor`(Attention: "Multifactor" must be after "Username Password Form");
 
 5. Press "Settings" for "Multifactor" and enter the following values:
-  * API key: value from step 1;
-  * API secret: value from step 1;
+  * API key / API secret: default credentials (fallback for local users);
+  * **Federation API keys (JSON)** (optional): per LDAP federation credentials. Federation name must match Keycloak User federation name, e.g. `{"ldap-alpha":{"key":"...","secret":"..."},"ldap-beta":{"key":"...","secret":"..."}}`;
   * API URL: https://api.multifactor.ru.
 
-6. Select `REQUIRED` under the Requirement column for "Multifactor". Save your configuration; 
+  Federated users use credentials from the JSON map by `user.federationLink` → federation component name. Users from federations not listed in the map use the default API key/secret.
+
+6. Select `REQUIRED` under the Requirement column for "Multifactor". Save your configuration;
 
 7. In your Keycloak client's settings, in the "Advanced" -> "Authentication Flow Overrides" section, bind your "Copy of browser" to the Browser Flow. Alternatively, you can bind new flow globally: In "Authentication" -> "Flow" select "Copy of browser" and click "Action->Bind flow".

--- a/src/main/java/ru/multifactor/keycloak/auth/spi/mf/FederationCredentialsResolver.java
+++ b/src/main/java/ru/multifactor/keycloak/auth/spi/mf/FederationCredentialsResolver.java
@@ -1,0 +1,97 @@
+package ru.multifactor.keycloak.auth.spi.mf;
+
+import org.json.JSONObject;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.component.ComponentModel;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+
+import static ru.multifactor.keycloak.auth.spi.mf.MultifactorAuthenticatorFactory.PROP_FEDERATION_MAP;
+import static ru.multifactor.keycloak.auth.spi.mf.MultifactorAuthenticatorFactory.PROP_KEY;
+import static ru.multifactor.keycloak.auth.spi.mf.MultifactorAuthenticatorFactory.PROP_SECRET;
+
+public final class FederationCredentialsResolver {
+
+    public static final class Credentials {
+        public final String apiKey;
+        public final String apiSecret;
+
+        Credentials(String apiKey, String apiSecret) {
+            this.apiKey = apiKey;
+            this.apiSecret = apiSecret;
+        }
+    }
+
+    private FederationCredentialsResolver() {
+    }
+
+    public static Credentials resolve(AuthenticationFlowContext context) {
+        AuthenticatorConfigModel config = context.getAuthenticatorConfig();
+        String defaultKey = "";
+        String defaultSecret = "";
+        String federationMapJson = null;
+
+        if (config != null && config.getConfig() != null) {
+            defaultKey = configValue(config.getConfig().get(PROP_KEY));
+            defaultSecret = configValue(config.getConfig().get(PROP_SECRET));
+            federationMapJson = configValue(config.getConfig().get(PROP_FEDERATION_MAP));
+            if (federationMapJson.isEmpty()) {
+                federationMapJson = null;
+            }
+        }
+
+        String federationName = federationName(context);
+        if (federationName != null && federationMapJson != null) {
+            Credentials federationCredentials = lookupFederationMap(federationMapJson, federationName);
+            if (federationCredentials != null) {
+                return federationCredentials;
+            }
+        }
+
+        return new Credentials(defaultKey, defaultSecret);
+    }
+
+    static String federationName(AuthenticationFlowContext context) {
+        UserModel user = context.getUser();
+        if (user == null) {
+            return null;
+        }
+        String federationLink = user.getFederationLink();
+        if (federationLink == null) {
+            return null;
+        }
+        RealmModel realm = context.getRealm();
+        ComponentModel component = realm.getComponent(federationLink);
+        if (component == null) {
+            return null;
+        }
+        return component.getName();
+    }
+
+    static Credentials lookupFederationMap(String mapJson, String federationName) {
+        try {
+            JSONObject map = new JSONObject(mapJson);
+            if (!map.has(federationName)) {
+                return null;
+            }
+            JSONObject entry = map.getJSONObject(federationName);
+            String key = entry.optString("key", "").trim();
+            String secret = entry.optString("secret", "").trim();
+            if (key.isEmpty() || secret.isEmpty()) {
+                return null;
+            }
+            return new Credentials(key, secret);
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private static String configValue(Object value) {
+        if (value == null) {
+            return "";
+        }
+        String text = String.valueOf(value).trim();
+        return "null".equals(text) ? "" : text;
+    }
+}

--- a/src/main/java/ru/multifactor/keycloak/auth/spi/mf/MultifactorAuthenticator.java
+++ b/src/main/java/ru/multifactor/keycloak/auth/spi/mf/MultifactorAuthenticator.java
@@ -210,7 +210,8 @@ public class MultifactorAuthenticator implements Authenticator{
           StringBuilder result=new StringBuilder("");
           String userId = getUserId(context,result);
           if(userId!=null) {
-          	if(apiRequest(apiURL(context)+"/access/requests", userId, apiKey(context), apiSecret(context), result))
+          	FederationCredentialsResolver.Credentials credentials = FederationCredentialsResolver.resolve(context);
+          	if(apiRequest(apiURL(context)+"/access/requests", userId, credentials.apiKey, credentials.apiSecret, result))
           		context.challenge(createMultifactorForm(context, result.toString(), null));
 	  	else if(result.toString().equals("API UNREACHABLE") && byPass(context)) context.success();
           	else context.challenge(createMultifactorForm(context, null, result.toString()));
@@ -231,7 +232,8 @@ public class MultifactorAuthenticator implements Authenticator{
         }
         String token= formData.getFirst("jwt_token");
         StringBuilder result=new StringBuilder("");
-        if(!chkToken(token, getUserId(context,null), apiKey(context), apiSecret(context), result))
+        FederationCredentialsResolver.Credentials credentials = FederationCredentialsResolver.resolve(context);
+        if(!chkToken(token, getUserId(context,null), credentials.apiKey, credentials.apiSecret, result))
 	{
             context.failureChallenge(AuthenticationFlowError.INVALID_CREDENTIALS, createMultifactorForm(context, null, result.toString()));
             return;
@@ -242,16 +244,6 @@ public class MultifactorAuthenticator implements Authenticator{
     @Override
     public void close() {}
 
-    private String apiKey(AuthenticationFlowContext context) {
-        AuthenticatorConfigModel config = context.getAuthenticatorConfig();
-        if (config == null) return "";
-        return String.valueOf(config.getConfig().get(PROP_KEY));
-    }
-    private String apiSecret(AuthenticationFlowContext context) {
-        AuthenticatorConfigModel config = context.getAuthenticatorConfig();
-        if (config == null) return "";
-        return String.valueOf(config.getConfig().get(PROP_SECRET));
-    }
     private String apiURL(AuthenticationFlowContext context) {
         AuthenticatorConfigModel config = context.getAuthenticatorConfig();
         if (config == null) return "";

--- a/src/main/java/ru/multifactor/keycloak/auth/spi/mf/MultifactorAuthenticatorFactory.java
+++ b/src/main/java/ru/multifactor/keycloak/auth/spi/mf/MultifactorAuthenticatorFactory.java
@@ -21,6 +21,7 @@ public class MultifactorAuthenticatorFactory implements AuthenticatorFactory{
     public static final String PROP_BYPASS = "multifactor.bypass";
     public static final String PROP_USE_EMAIL = "multifactor.use_email";
     public static final String PROP_USER_ATTRIBUTE = "multifactor.user_attribute";
+    public static final String PROP_FEDERATION_MAP = "multifactor.federation.map";
 
 
     @Override
@@ -100,6 +101,16 @@ public class MultifactorAuthenticatorFactory implements AuthenticatorFactory{
         user_attribute.setHelpText("Send this user attribute to the multifactor api instead of username");
         configProperties.add(user_attribute);
 
+        ProviderConfigProperty federation_map = new ProviderConfigProperty();
+        federation_map.setName(PROP_FEDERATION_MAP);
+        federation_map.setLabel("Federation API keys (JSON)");
+        federation_map.setType(ProviderConfigProperty.TEXT_TYPE);
+        federation_map.setHelpText(
+                "Per LDAP federation credentials. Keys are federation names from User federation "
+                        + "(e.g. ldap-alpha, ldap-beta). Example: {\"ldap-alpha\":{\"key\":\"...\",\"secret\":\"...\"}}. "
+                        + "Federated users without a matching entry use Default Api Key/Secret above."
+        );
+        configProperties.add(federation_map);
 
     }
 


### PR DESCRIPTION
Add optional Federation API keys (JSON) config property. Federated users resolve key/secret by user federation component name; others use the default Api Key/Secret.

Closes MultifactorLab/multifactor-keycloak-plugin#5

## Summary

Implements #5.

- Optional **Federation API keys (JSON)** authenticator setting (`ProviderConfigProperty.TEXT_TYPE`)
- Resolve Multifactor API key/secret by LDAP federation component name (`user.federationLink`)
- Fallback to default Api Key/Secret for local users and federations not listed in the map

## Example

```json
{
  "ldap-alpha": { "key": "...", "secret": "..." },
  "ldap-beta": { "key": "...", "secret": "..." }
}